### PR TITLE
Updated Procfile to use gevent worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn httpbin:app -w 6
+web: gunicorn httpbin:app --log-file - --worker-class gevent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 decorator==3.4.0
 Flask==0.10.1
 gevent==1.0.1
-greenlet==0.4.2
-gunicorn==18.0
+greenlet==0.4.5
+gunicorn==19.1.1
 itsdangerous==0.24
 Jinja2==2.7.2
 MarkupSafe==0.23


### PR DESCRIPTION
I was making a few requests to the delay endpoint and ended blocking any subsequent requests I was making (and presumably for other people). In the Procfile, 6 workers are specified and I'm guessing there are two dynos running, so after 12 concurrent requests the rest will block.

Since the max delay is 10 seconds this issue isn't likely to be such a big deal but considering that you already had gevent and gunicorn specified in the requirements why not just use an async worker.