### PR TITLE
Restore gunicorn in the list of third-party requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ decorator==3.4.0
 Flask==0.10.1
 gevent==1.0.1
 greenlet==0.4.2
+gunicorn==19.2
 itsdangerous==0.24
 Jinja2==2.7.2
 MarkupSafe==0.23


### PR DESCRIPTION
`gunicorn==18.0` had previously been listed in requirements.txt, but I
removed it in commit d851a7e2a1a3239dd853ff88f918e1c52cf4b8f4 for
compatibility with the new httpbin.org hosting platform.

gunicorn 19.2 has (finally) been released, and this version will work
correctly for httpbin.org. This change adds `gunicorn==19.2` back to
requirements.txt.

This may also fix problems deploying to Heroku reported by @sigmavirus24,
which may have been caused by the requirement change in
d851a7e2a1a3239dd853ff88f918e1c52cf4b8f4.