### PR TITLE
Fix hurl.it links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ Originally created by `Kenneth Reitz <http://kennethreitz.com/>`__.
 SEE ALSO
 --------
 
-- https://hurl.it
+- https://www.hurl.it
 - http://requestb.in
 - http://python-requests.org
 

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -147,7 +147,7 @@ $ gunicorn httpbin:app
 
 <h2 id="SEE-ALSO">SEE ALSO</h2>
 
-<p><a href="https://hurl.it">Hurl.it</a> - Make HTTP requests.</p>
+<p><a href="https://www.hurl.it">Hurl.it</a> - Make HTTP requests.</p>
 <p><a href="http://requestb.in">RequestBin</a> - Inspect HTTP requests.</p>
 <p><a href="http://python-requests.org" data-bare-link="true">http://python-requests.org</a></p>
 


### PR DESCRIPTION
This needs to be `https://www.hurl.it`:

    ❯ curl -IL https://hurl.it/
    curl: (7) Failed to connect to hurl.it port 443: Connection refused

---

    ❯ curl -IL https://www.hurl.it/
    HTTP/1.1 200 OK