### PR TITLE
Enable running httpbin under a URL Prefix.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,37 @@ Or run it directly:
 
     $ python -m httpbin.core
 
+Running with a URL prefix
+-------------------------
+
+If you'd like to run httpbin with a url prefix
+
+.. code:: bash
+
+    $ HTTPBIN_URL_PREFIX="/httpbin" gunicorn httpbin:app
+
+Or
+
+.. code:: bash
+
+    $ HTTPBIN_URL_PREFIX="/httpbin" python -m httpbin.core
+
+Now all the routes act appropriately with the new prefix
+
+.. code:: bash
+
+    $ curl localhost:8080/httpbin/get
+    {
+      "args": {},
+      "headers": {
+        "Accept": "*/*",
+        "Host": "localhost:8000",
+        "User-Agent": "curl/7.35.0"
+      },
+      "origin": "127.0.0.1",
+      "url": "http://localhost:8000/httpbin/get"
+    }
+
 Changelog
 ---------
 

--- a/httpbin/templates/forms-post.html
+++ b/httpbin/templates/forms-post.html
@@ -4,7 +4,7 @@
   </head>
   <body>
   <!-- Example form from HTML5 spec http://www.w3.org/TR/html5/forms.html#writing-a-form's-user-interface -->
-  <form method="post" action="{{ url_for('view_post') }}">
+  <form method="post" action="{{ url_for('httpbin.view_post') }}">
    <p><label>Customer name: <input name="custname"></label></p>
    <p><label>Telephone: <input type=tel name="custtel"></label></p>
    <p><label>E-mail address: <input type=email name="custemail"></label></p>

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -5,48 +5,48 @@
 <h2 id="ENDPOINTS">ENDPOINTS</h2>
 
 <ul>
-<li><a href="{{ url_for('view_landing_page') }}" data-bare-link="true"><code>/</code></a> This page.</li>
-<li><a href="{{ url_for('view_origin') }}" data-bare-link="true"><code>/ip</code></a> Returns Origin IP.</li>
-<li><a href="{{ url_for('view_user_agent') }}" data-bare-link="true"><code>/user-agent</code></a> Returns user-agent.</li>
-<li><a href="{{ url_for('view_headers') }}" data-bare-link="true"><code>/headers</code></a> Returns header dict.</li>
-<li><a href="{{ url_for('view_get') }}" data-bare-link="true"><code>/get</code></a> Returns GET data.</li>
+<li><a href="{{ url_for('httpbin.view_landing_page') }}" data-bare-link="true"><code>/</code></a> This page.</li>
+<li><a href="{{ url_for('httpbin.view_origin') }}" data-bare-link="true"><code>/ip</code></a> Returns Origin IP.</li>
+<li><a href="{{ url_for('httpbin.view_user_agent') }}" data-bare-link="true"><code>/user-agent</code></a> Returns user-agent.</li>
+<li><a href="{{ url_for('httpbin.view_headers') }}" data-bare-link="true"><code>/headers</code></a> Returns header dict.</li>
+<li><a href="{{ url_for('httpbin.view_get') }}" data-bare-link="true"><code>/get</code></a> Returns GET data.</li>
 <li><code>/post</code> Returns POST data.</li>
 <li><code>/patch</code> Returns PATCH data.</li>
 <li><code>/put</code> Returns PUT data.</li>
 <li><code>/delete</code> Returns DELETE data</li>
-<li><a href="{{ url_for('encoding') }}"><code>/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
-<li><a href="{{ url_for('view_gzip_encoded_content') }}" data-bare-link="true"><code>/gzip</code></a> Returns gzip-encoded data.</li>
-<li><a href="{{ url_for('view_deflate_encoded_content') }}" data-bare-link="true"><code>/deflate</code></a> Returns deflate-encoded data.</li>
-<li><a href="{{ url_for('view_status_code', codes='418') }}"><code>/status/:code</code></a> Returns given HTTP Status code.</li>
-<li><a href="{{ url_for('response_headers', **{'Content-Type': 'text/plain; charset=UTF-8', 'Server': 'httpbin'}) }}"><code>/response-headers?key=val</code></a> Returns given response headers.</li>
-<li><a href="{{ url_for('redirect_n_times', n=6) }}"><code>/redirect/:n</code></a> 302 Redirects <em>n</em> times.</li>
-<li><a href="{{ url_for('redirect_to', url='http://example.com/') }}"><code>/redirect-to?url=foo</code></a> 302 Redirects to the <em>foo</em> URL.</li>
-<li><a href="{{ url_for('relative_redirect_n_times', n=6) }}"><code>/relative-redirect/:n</code></a> 302 Relative redirects <em>n</em> times.</li>
-<li><a href="{{ url_for('absolute_redirect_n_times', n=6) }}"><code>/absolute-redirect/:n</code></a> 302 Absolute redirects <em>n</em> times.</li>
-<li><a href="{{ url_for('view_cookies') }}" data-bare-link="true"><code>/cookies</code></a> Returns cookie data.</li>
-<li><a href="{{ url_for('set_cookies', k1='v1', k2='v2') }}"><code>/cookies/set?name=value</code></a> Sets one or more simple cookies.</li>
-<li><a href="{{ url_for('delete_cookies', k1='', k2='') }}"><code>/cookies/delete?name</code></a> Deletes one or more simple cookies.</li>
-<li><a href="{{ url_for('basic_auth', user='user', passwd='passwd') }}"><code>/basic-auth/:user/:passwd</code></a> Challenges HTTPBasic Auth.</li>
-<li><a href="{{ url_for('hidden_basic_auth', user='user', passwd='passwd') }}"><code>/hidden-basic-auth/:user/:passwd</code></a> 404'd BasicAuth.</li>
-<li><a href="{{ url_for('digest_auth', qop='auth', user='user', passwd='passwd') }}"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
-<li><a href="{{ url_for('stream_n_messages', n=20) }}"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
-<li><a href="{{ url_for('delay_response', delay=3) }}"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
-<li><a href="{{ url_for('drip', numbytes=5, duration=5, code=200) }}"><code>/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over a duration after an optional initial delay, then (optionally) returns with the given status code.</li>
-<li><a href="{{ url_for('range_request', numbytes=1024) }}"><code>/range/1024?duration=s&amp;chunk_size=code</code></a> Streams <em>n</em> bytes, and allows specifying a <em>Range</em> header to select a subset of the data. Accepts a <em>chunk_size</em> and request <em>duration</em> parameter.</li>
-<li><a href="{{ url_for('view_html_page') }}" data-bare-link="true"><code>/html</code></a> Renders an HTML Page.</li>
-<li><a href="{{ url_for('view_robots_page') }}" data-bare-link="true"><code>/robots.txt</code></a> Returns some robots.txt rules.</li>
-<li><a href="{{ url_for('view_deny_page') }}" data-bare-link="true"><code>/deny</code></a> Denied by robots.txt file.</li>
-<li><a href="{{ url_for('cache') }}" data-bare-link="true"><code>/cache</code></a> Returns 200 unless an If-Modified-Since or If-None-Match header is provided, when it returns a 304.</li>
-<li><a href="{{ url_for('cache_control', value=60) }}"><code>/cache/:n</code></a> Sets a Cache-Control header for <em>n</em> seconds.</li>
-<li><a href="{{ url_for('random_bytes', n=1024) }}"><code>/bytes/:n</code></a> Generates <em>n</em> random bytes of binary data, accepts optional <em>seed</em> integer parameter.</li>
-<li><a href="{{ url_for('stream_random_bytes', n=1024) }}"><code>/stream-bytes/:n</code></a> Streams <em>n</em> random bytes of binary data, accepts optional <em>seed</em> and <em>chunk_size</em> integer parameters.</li>
-<li><a href="{{ url_for('links', n=10) }}"><code>/links/:n</code></a> Returns page containing <em>n</em> HTML links.</li>
-<li><a href="{{ url_for('image') }}"><code>/image</code></a> Returns page containing an image.</li>
-<li><a href="{{ url_for('image_png') }}"><code>/image/png</code></a> Returns page containing a PNG image.</li>
-<li><a href="{{ url_for('image_jpeg') }}"><code>/image/jpeg</code></a> Returns page containing a JPEG image.</li>
-<li><a href="{{ url_for('image_webp') }}"><code>/image/webp</code></a> Returns page containing a WEBP image.</li>
-<li><a href="{{ url_for('view_forms_post') }}" data-bare-link="true"><code>/forms/post</code></a> HTML form that submits to <em>/post</em></li>
-<li><a href="{{ url_for('xml') }}" data-bare-link="true"><code>/xml</code></a> Returns some XML</li>
+<li><a href="{{ url_for('httpbin.encoding') }}"><code>/encoding/utf8</code></a> Returns page containing UTF-8 data.</li>
+<li><a href="{{ url_for('httpbin.view_gzip_encoded_content') }}" data-bare-link="true"><code>/gzip</code></a> Returns gzip-encoded data.</li>
+<li><a href="{{ url_for('httpbin.view_deflate_encoded_content') }}" data-bare-link="true"><code>/deflate</code></a> Returns deflate-encoded data.</li>
+<li><a href="{{ url_for('httpbin.view_status_code', codes='418') }}"><code>/status/:code</code></a> Returns given HTTP Status code.</li>
+<li><a href="{{ url_for('httpbin.response_headers', **{'Content-Type': 'text/plain; charset=UTF-8', 'Server': 'httpbin'}) }}"><code>/response-headers?key=val</code></a> Returns given response headers.</li>
+<li><a href="{{ url_for('httpbin.redirect_n_times', n=6) }}"><code>/redirect/:n</code></a> 302 Redirects <em>n</em> times.</li>
+<li><a href="{{ url_for('httpbin.redirect_to', url='http://example.com/') }}"><code>/redirect-to?url=foo</code></a> 302 Redirects to the <em>foo</em> URL.</li>
+<li><a href="{{ url_for('httpbin.relative_redirect_n_times', n=6) }}"><code>/relative-redirect/:n</code></a> 302 Relative redirects <em>n</em> times.</li>
+<li><a href="{{ url_for('httpbin.absolute_redirect_n_times', n=6) }}"><code>/absolute-redirect/:n</code></a> 302 Absolute redirects <em>n</em> times.</li>
+<li><a href="{{ url_for('httpbin.view_cookies') }}" data-bare-link="true"><code>/cookies</code></a> Returns cookie data.</li>
+<li><a href="{{ url_for('httpbin.set_cookies', k1='v1', k2='v2') }}"><code>/cookies/set?name=value</code></a> Sets one or more simple cookies.</li>
+<li><a href="{{ url_for('httpbin.delete_cookies', k1='', k2='') }}"><code>/cookies/delete?name</code></a> Deletes one or more simple cookies.</li>
+<li><a href="{{ url_for('httpbin.basic_auth', user='user', passwd='passwd') }}"><code>/basic-auth/:user/:passwd</code></a> Challenges HTTPBasic Auth.</li>
+<li><a href="{{ url_for('httpbin.hidden_basic_auth', user='user', passwd='passwd') }}"><code>/hidden-basic-auth/:user/:passwd</code></a> 404'd BasicAuth.</li>
+<li><a href="{{ url_for('httpbin.digest_auth', qop='auth', user='user', passwd='passwd') }}"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
+<li><a href="{{ url_for('httpbin.stream_n_messages', n=20) }}"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
+<li><a href="{{ url_for('httpbin.delay_response', delay=3) }}"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
+<li><a href="{{ url_for('httpbin.drip', numbytes=5, duration=5, code=200) }}"><code>/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over a duration after an optional initial delay, then (optionally) returns with the given status code.</li>
+<li><a href="{{ url_for('httpbin.range_request', numbytes=1024) }}"><code>/range/1024?duration=s&amp;chunk_size=code</code></a> Streams <em>n</em> bytes, and allows specifying a <em>Range</em> header to select a subset of the data. Accepts a <em>chunk_size</em> and request <em>duration</em> parameter.</li>
+<li><a href="{{ url_for('httpbin.view_html_page') }}" data-bare-link="true"><code>/html</code></a> Renders an HTML Page.</li>
+<li><a href="{{ url_for('httpbin.view_robots_page') }}" data-bare-link="true"><code>/robots.txt</code></a> Returns some robots.txt rules.</li>
+<li><a href="{{ url_for('httpbin.view_deny_page') }}" data-bare-link="true"><code>/deny</code></a> Denied by robots.txt file.</li>
+<li><a href="{{ url_for('httpbin.cache') }}" data-bare-link="true"><code>/cache</code></a> Returns 200 unless an If-Modified-Since or If-None-Match header is provided, when it returns a 304.</li>
+<li><a href="{{ url_for('httpbin.cache_control', value=60) }}"><code>/cache/:n</code></a> Sets a Cache-Control header for <em>n</em> seconds.</li>
+<li><a href="{{ url_for('httpbin.random_bytes', n=1024) }}"><code>/bytes/:n</code></a> Generates <em>n</em> random bytes of binary data, accepts optional <em>seed</em> integer parameter.</li>
+<li><a href="{{ url_for('httpbin.stream_random_bytes', n=1024) }}"><code>/stream-bytes/:n</code></a> Streams <em>n</em> random bytes of binary data, accepts optional <em>seed</em> and <em>chunk_size</em> integer parameters.</li>
+<li><a href="{{ url_for('httpbin.links', n=10) }}"><code>/links/:n</code></a> Returns page containing <em>n</em> HTML links.</li>
+<li><a href="{{ url_for('httpbin.image') }}"><code>/image</code></a> Returns page containing an image.</li>
+<li><a href="{{ url_for('httpbin.image_png') }}"><code>/image/png</code></a> Returns page containing a PNG image.</li>
+<li><a href="{{ url_for('httpbin.image_jpeg') }}"><code>/image/jpeg</code></a> Returns page containing a JPEG image.</li>
+<li><a href="{{ url_for('httpbin.image_webp') }}"><code>/image/webp</code></a> Returns page containing a WEBP image.</li>
+<li><a href="{{ url_for('httpbin.view_forms_post') }}" data-bare-link="true"><code>/forms/post</code></a> HTML form that submits to <em>/post</em></li>
+<li><a href="{{ url_for('httpbin.xml') }}" data-bare-link="true"><code>/xml</code></a> Returns some XML</li>
 </ul>
 
 


### PR DESCRIPTION
Refactors httpbin into a Flask Blueprint and enables mounting it under a given Prefix when exposing the WSGI application.

Has the added benefit of allowing people to embed httpbin in their chosen Flask project... if that's something they're keen on.