### PR TITLE
Do not forcefully emit Transfer-Encoding header

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -280,7 +280,6 @@ def stream_n_messages(n):
             yield json.dumps(response) + '\n'
 
     return Response(generate_stream(), headers={
-        "Transfer-Encoding": "chunked",
         "Content-Type": "application/json",
         })
 
@@ -553,8 +552,7 @@ def stream_random_bytes(n):
         if chunks:
             yield(bytes(chunks))
 
-    headers = {'Transfer-Encoding': 'chunked',
-               'Content-Type': 'application/octet-stream'}
+    headers = {'Content-Type': 'application/octet-stream'}
 
     return Response(generate_bytes(), headers=headers)
 
@@ -570,7 +568,7 @@ def range_request(numbytes):
         response.status_code = 404
         response.data = 'number of bytes must be in the range (0, 10240]'
         return response
-    
+
     params = CaseInsensitiveDict(request.args.items())
     if 'chunk_size' in params:
         chunk_size = max(1, int(params['chunk_size']))
@@ -611,7 +609,6 @@ def range_request(numbytes):
 
     content_range = 'bytes %d-%d/%d' % (first_byte_pos, last_byte_pos, numbytes)
     response_headers = {
-        'Transfer-Encoding': 'chunked',
         'Content-Type': 'application/octet-stream',
         'ETag' : 'range%d' % numbytes,
         'Accept-Ranges' : 'bytes',


### PR DESCRIPTION
Discovered when attempting to use pytest-httpbin with requests (see kennethreitz/requests#2184 and kevin1024/pytest-httpbin#27).

It turns out that the WSGI specification *specifically forbids* implementations from emitting the `Transfer-Encoding` header, as noted in [this part of PEP 333](https://www.python.org/dev/peps/pep-0333/#other-http-features) (emphasis in the original):

> WSGI applications **must not** generate any "hop-by-hop" headers, attempt to use HTTP features that would require them to generate such headers, or rely on the content of any incoming "hop-by-hop" headers in the `environ` dictionary.

Now, it's extremely clear that certain WSGI servers allow the use of generators to generate chunked transfer encoding, and gunicorn is one of them. More importantly, they do this *regardless* of whether the application attempts to set the `Transfer-Encoding` header or not: this is simply how gunicorn does chunked transfer encoding. However, on WSGI servers that *don't* do this (e.g. wsgiref), attempting to emit a `Transfer-Encoding` header can cause a 500 error.

For this reason, httpbin simply shouldn't insist on emitting the header itself: instead, let the web server do it.