### PR TITLE
Added support for another Digest algorithm, SHA256.

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -405,8 +405,12 @@ def hidden_basic_auth(user='user', passwd='passwd'):
     return jsonify(authenticated=True, user=user)
 
 
-@app.route('/digest-auth/<algorithm>/<qop>/<user>/<passwd>')
-def digest_auth(algorithm='MD5', qop=None, user='user', passwd='passwd'):
+@app.route('/digest-auth/<qop>/<user>/<passwd>')
+def digest_auth_md5(qop=None, user='user', passwd='passwd'):
+    return digest_auth(qop, user, passwd, "MD5")
+
+@app.route('/digest-auth/<qop>/<user>/<passwd>/<algorithm>')
+def digest_auth(qop=None, user='user', passwd='passwd', algorithm='MD5'):
     """Prompts the user for authorization using HTTP Digest auth"""
     if algorithm not in ('MD5', 'SHA-256'):
         algorithm = 'MD5'

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -28,7 +28,7 @@
 <li><a href="{{ url_for('delete_cookies', k1='', k2='') }}"><code>/cookies/delete?name</code></a> Deletes one or more simple cookies.</li>
 <li><a href="{{ url_for('basic_auth', user='user', passwd='passwd') }}"><code>/basic-auth/:user/:passwd</code></a> Challenges HTTPBasic Auth.</li>
 <li><a href="{{ url_for('hidden_basic_auth', user='user', passwd='passwd') }}"><code>/hidden-basic-auth/:user/:passwd</code></a> 404'd BasicAuth.</li>
-<li><a href="{{ url_for('digest_auth', algorithm='MD5', qop='auth', user='user', passwd='passwd') }}"><code>/digest-auth/:algorithm/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
+<li><a href="{{ url_for('digest_auth', qop='auth', user='user', passwd='passwd', algorithm='MD5') }}"><code>/digest-auth/:qop/:user/:passwd/:algorithm</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="{{ url_for('stream_n_messages', n=20) }}"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
 <li><a href="{{ url_for('delay_response', delay=3) }}"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
 <li><a href="{{ url_for('drip', numbytes=5, duration=5, code=200) }}"><code>/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over a duration after an optional initial delay, then (optionally) returns with the given status code.</li>

--- a/httpbin/templates/httpbin.1.html
+++ b/httpbin/templates/httpbin.1.html
@@ -28,7 +28,7 @@
 <li><a href="{{ url_for('delete_cookies', k1='', k2='') }}"><code>/cookies/delete?name</code></a> Deletes one or more simple cookies.</li>
 <li><a href="{{ url_for('basic_auth', user='user', passwd='passwd') }}"><code>/basic-auth/:user/:passwd</code></a> Challenges HTTPBasic Auth.</li>
 <li><a href="{{ url_for('hidden_basic_auth', user='user', passwd='passwd') }}"><code>/hidden-basic-auth/:user/:passwd</code></a> 404'd BasicAuth.</li>
-<li><a href="{{ url_for('digest_auth', qop='auth', user='user', passwd='passwd') }}"><code>/digest-auth/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
+<li><a href="{{ url_for('digest_auth', algorithm='MD5', qop='auth', user='user', passwd='passwd') }}"><code>/digest-auth/:algorithm/:qop/:user/:passwd</code></a> Challenges HTTP Digest Auth.</li>
 <li><a href="{{ url_for('stream_n_messages', n=20) }}"><code>/stream/:n</code></a> Streams <em>n</em>–100 lines.</li>
 <li><a href="{{ url_for('delay_response', delay=3) }}"><code>/delay/:n</code></a> Delays responding for <em>n</em>–10 seconds.</li>
 <li><a href="{{ url_for('drip', numbytes=5, duration=5, code=200) }}"><code>/drip?numbytes=n&amp;duration=s&amp;delay=s&amp;code=code</code></a> Drips data over a duration after an optional initial delay, then (optionally) returns with the given status code.</li>

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -164,9 +164,9 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_digest_auth_with_wrong_password(self):
-        auth_header = 'Digest username="user",realm="wrong",nonce="wrong",uri="/digest-auth/MD5/user/passwd",response="wrong",opaque="wrong"'
+        auth_header = 'Digest username="user",realm="wrong",nonce="wrong",uri="/digest-auth/user/passwd/MD5",response="wrong",opaque="wrong"'
         response = self.app.get(
-            '/digest-auth/MD5/auth/user/passwd',
+            '/digest-auth/auth/user/passwd/MD5',
             environ_base={
                 # httpbin's digest auth implementation uses the remote addr to
                 # build the nonce
@@ -181,7 +181,7 @@ class HttpbinTestCase(unittest.TestCase):
     def test_digest_auth(self):
         # make first request
         unauthorized_response = self.app.get(
-            '/digest-auth/MD5/auth/user/passwd',
+            '/digest-auth/auth/user/passwd/MD5',
             environ_base={
                 # digest auth uses the remote addr to build the nonce
                 'REMOTE_ADDR': '127.0.0.1',
@@ -196,7 +196,7 @@ class HttpbinTestCase(unittest.TestCase):
         d = parse_dict_header(auth_info)
         a1 = b'user:' + d['realm'].encode('utf-8') + b':passwd'
         ha1 = md5(a1).hexdigest().encode('utf-8')
-        a2 = b'GET:/digest-auth/MD5/auth/user/passwd'
+        a2 = b'GET:/digest-auth/auth/user/passwd/MD5'
         ha2 = md5(a2).hexdigest().encode('utf-8')
         a3 = ha1 + b':' + d['nonce'].encode('utf-8') + b':' + ha2
         auth_response = md5(a3).hexdigest()
@@ -204,14 +204,14 @@ class HttpbinTestCase(unittest.TestCase):
             d['realm'] + \
             '",nonce="' + \
             d['nonce'] + \
-            '",uri="/digest-auth/MD5/auth/user/passwd",response="' + \
+            '",uri="/digest-auth/auth/user/passwd/MD5",response="' + \
             auth_response + \
             '",opaque="' + \
             d['opaque'] + '"'
 
         # make second request
         authorized_response = self.app.get(
-            '/digest-auth/MD5/auth/user/passwd',
+            '/digest-auth/auth/user/passwd/MD5',
             environ_base={
                 # httpbin's digest auth implementation uses the remote addr to
                 # build the nonce

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -164,9 +164,9 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_digest_auth_with_wrong_password(self):
-        auth_header = 'Digest username="user",realm="wrong",nonce="wrong",uri="/digest-auth/user/passwd",response="wrong",opaque="wrong"'
+        auth_header = 'Digest username="user",realm="wrong",nonce="wrong",uri="/digest-auth/MD5/user/passwd",response="wrong",opaque="wrong"'
         response = self.app.get(
-            '/digest-auth/auth/user/passwd',
+            '/digest-auth/MD5/auth/user/passwd',
             environ_base={
                 # httpbin's digest auth implementation uses the remote addr to
                 # build the nonce
@@ -181,7 +181,7 @@ class HttpbinTestCase(unittest.TestCase):
     def test_digest_auth(self):
         # make first request
         unauthorized_response = self.app.get(
-            '/digest-auth/auth/user/passwd',
+            '/digest-auth/MD5/auth/user/passwd',
             environ_base={
                 # digest auth uses the remote addr to build the nonce
                 'REMOTE_ADDR': '127.0.0.1',
@@ -196,7 +196,7 @@ class HttpbinTestCase(unittest.TestCase):
         d = parse_dict_header(auth_info)
         a1 = b'user:' + d['realm'].encode('utf-8') + b':passwd'
         ha1 = md5(a1).hexdigest().encode('utf-8')
-        a2 = b'GET:/digest-auth/auth/user/passwd'
+        a2 = b'GET:/digest-auth/MD5/auth/user/passwd'
         ha2 = md5(a2).hexdigest().encode('utf-8')
         a3 = ha1 + b':' + d['nonce'].encode('utf-8') + b':' + ha2
         auth_response = md5(a3).hexdigest()
@@ -204,14 +204,14 @@ class HttpbinTestCase(unittest.TestCase):
             d['realm'] + \
             '",nonce="' + \
             d['nonce'] + \
-            '",uri="/digest-auth/auth/user/passwd",response="' + \
+            '",uri="/digest-auth/MD5/auth/user/passwd",response="' + \
             auth_response + \
             '",opaque="' + \
             d['opaque'] + '"'
 
         # make second request
         authorized_response = self.app.get(
-            '/digest-auth/auth/user/passwd',
+            '/digest-auth/MD5/auth/user/passwd',
             environ_base={
                 # httpbin's digest auth implementation uses the remote addr to
                 # build the nonce


### PR DESCRIPTION
RFC 7616 specifies other algorithms for Http Digest:
http://tools.ietf.org/html/rfc7616

I've added support for multiple algorithms in the URLs:
Old:
https://httpbin.org/digest-auth/auth/user/passwd
New:
https://httpbin.org/digest-auth/MD5/auth/user/passwd
https://httpbin.org/digest-auth/SHA-256/auth/user/passwd