### PR TITLE
Floating point type conversion

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -441,7 +441,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
 @app.route('/delay/<delay>')
 def delay_response(delay):
     """Returns a delayed response"""
-    delay = min(delay, 10)
+    delay = min(float(delay), 10)
 
     time.sleep(delay)
 


### PR DESCRIPTION
Apologies, but my last pull request, which was merged in https://github.com/Runscope/httpbin/commit/4763d4761407dce3a99be3c6640c14dcd4be30fe, was merged with a bug.

Since the int constraint is removed to allow for floats, the delay parameter comes in as unicode. 
I'm not exactly sure how the unicode is compared with the integer 10, but this obviously creates undesirable delays -- 10 ends up being smaller than whatever number the min function interprets the unicode as.

I've run this with delay between 1 - 10 and 0 - 1 and they all return 10.

Sorry again for the trouble. Hopefully there won't be any more.