### PR TITLE
Changelog and setup updated for floating point support 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ Or run it directly:
 
 Changelog
 ---------
-
+-  0.4.1: Added floating-point support for /delay endpoint
 -  0.4.0: New /image/svg endpoint, add deploy to heroku button, add 406 response to /image, and don't always emit the transfer-encoding header for stream endpoint.
 -  0.3.0: A number of new features, including a /range endpoint, lots of
    bugfixes, and a /encoding/utf8 endpoint

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = open(
 
 setup(
     name="httpbin",
-    version="0.4.0",
+    version="0.4.1",
     description="HTTP Request and Response Service",
     long_description=long_description,
 


### PR DESCRIPTION
This is the separate PR for updating the changelog and setup.py file, as requested here: https://github.com/Runscope/httpbin/pull/266