### PR TITLE
Add machinery to create/upload releases

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,15 @@
 [tox]
 envlist = py27,py34
+
 [testenv]
 commands=python test_httpbin.py
+
+[testenv:release]
+skipdist = true
+usedevelop = false
+deps =
+    twine>=1.6.0
+    wheel
+commands =
+    python setup.py sdist bdist_wheel
+    twine upload --skip-existing dist/*


### PR DESCRIPTION
This uses twine to upload wheels and source distributions that we create
for httpbin.