### PR TITLE
Add basic /short endpoint.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ Endpoint                                 Description
 `/forms/post`_                           HTML form that submits to */post*
 `/xml`_                                  Returns some XML
 `/encoding/utf8`_                        Returns page containing UTF-8 data.
+`/short`_                                Returns a page with wrong content-length.
 ======================================   ==================================================================================================================
 
 .. _/user-agent: http://httpbin.org/user-agent

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -707,6 +707,14 @@ def xml():
     response.headers["Content-Type"] = "application/xml"
     return response
 
+@app.route("/short")
+def short():
+    response = Response(['*'], headers={
+        "Content-Type": "application/octet-stream",
+        "Content-Length": 2,
+    })
+    response.status_code = 200
+    return response
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
Reports a content-length of 2 but only returns a single byte.

Useful for testing a bad/lossy connection or a server that returns malformed data.