### PR TITLE
Added supports for non-get redirect-to with other status_code

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -224,9 +224,9 @@ def _redirect(kind, n, external):
     return redirect(url_for('{0}_redirect_n_times'.format(kind), n=n - 1, _external=external))
 
 
-@app.route('/redirect-to')
+@app.route('/redirect-to', methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'TRACE'])
 def redirect_to():
-    """302 Redirects to the given URL."""
+    """302/3XX Redirects to the given URL."""
 
     args = CaseInsensitiveDict(request.args.items())
 
@@ -235,6 +235,10 @@ def redirect_to():
     # header to the exact string supplied.
     response = app.make_response('')
     response.status_code = 302
+    if 'status_code' in args:
+        status_code = int(args['status_code'])
+        if status_code >= 300 and status_code < 400:
+            response.status_code = status_code
     response.headers['Location'] = args['url'].encode('utf-8')
 
     return response

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -316,6 +316,15 @@ class HttpbinTestCase(unittest.TestCase):
             response.headers.get('Location'), '/relative-redirect/4'
         )
 
+    def test_redirect_to_post(self):
+        response = self.app.post('/redirect-to?url=/post&status_code=307',
+                                 data=b'\x01\x02\x03\x81\x82\x83',
+                                 content_type='application/octet-stream')
+        self.assertEqual(response.status_code, 307)
+        self.assertEqual(
+            response.headers.get('Location'), '/post'
+        )
+
     def test_redirect_absolute_param_n_higher_than_1(self):
         response = self.app.get('/redirect/5?absolute=true')
         self.assertEqual(


### PR DESCRIPTION
This is an idea for PR https://github.com/Runscope/httpbin/issues/283 it is sufficient for debugging the bug in https://github.com/kennethreitz/requests/issues/3079