### PR TITLE
added other methods to the delay endpoint, added tests for delay

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -439,7 +439,7 @@ def digest_auth(qop=None, user='user', passwd='passwd'):
     return jsonify(authenticated=True, user=user)
 
 
-@app.route('/delay/<delay>')
+@app.route('/delay/<delay>', methods=('GET', 'POST', 'PUT', ))
 def delay_response(delay):
     """Returns a delayed response"""
     delay = min(float(delay), 10)

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -9,7 +9,7 @@ import json
 from werkzeug.http import parse_dict_header
 from hashlib import md5
 from six import BytesIO
-
+import time
 import httpbin
 
 
@@ -452,6 +452,28 @@ class HttpbinTestCase(unittest.TestCase):
         data = response.data.decode('utf-8')
         self.assertIn('google-analytics', data)
         self.assertIn('perfectaudience', data)
+
+    def test_delay_get(self):
+        start_time = time.time()
+        response = self.app.get('/delay/2')
+        end_time = time.time()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(end_time - start_time, 2)
+
+    def test_delay_post(self):
+        start_time = time.time()
+        response = self.app.post('/delay/2')
+        end_time = time.time()
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(end_time - start_time, 2)
+
+    def test_delay_put(self):
+        start_time = time.time()
+        response = self.app.put('/delay/2')
+        end_time = time.time()
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(end_time - start_time, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A pull request to add other HTTP methods to the "delay" endpoint.  For testing it is nice to be able to test a slow down for more than just a GET.  I added POST and PUT.  Perhaps others could be added but I know that these are useful.  I also added some tests for the three delay methods.

I notice that the unit tests are failing but it doesn't appear to be in the code I changed.  test_response_headers_multi and test_response_headers_simple are both failing.