### PR TITLE
Don't check Content-Length header anymore

### DIFF
--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -315,7 +315,7 @@ def response_headers():
     response = jsonify(headers.lists())
 
     while True:
-        content_len_shown = response.headers['Content-Length']
+        original_data = response.data
         d = {}
         for key in response.headers.keys():
             value = response.headers.get_all(key)
@@ -325,7 +325,8 @@ def response_headers():
         response = jsonify(d)
         for key, value in headers.items(multi=True):
             response.headers.add(key, value)
-        if response.headers['Content-Length'] == content_len_shown:
+        response_has_changed = response.data != original_data
+        if not response_has_changed:
             break
     return response
 

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -312,7 +312,7 @@ def view_status_code(codes):
 def response_headers():
     """Returns a set of response headers from the query string """
     headers = MultiDict(request.args.items(multi=True))
-    response = jsonify(headers.lists())
+    response = jsonify(list(headers.lists()))
 
     while True:
         original_data = response.data


### PR DESCRIPTION
Because it is not present in Flask 0.11. We keep merging the headers from the `headers` variable with the headers from the `response.headers`, because changing the response may change the headers, especially the `Content-Length` header. In Flask 0.11 this `Content-Length` header is no longer present in the `response.headers`, so we check whether the `response.data` has changed.

Fixes #290