### PR TITLE
use io.open() for long_description from file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from setuptools import setup, find_packages
 import os
+import io
 
-long_description = open(
-    os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+long_description = io.open(
+    os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8').read()
 
 setup(
     name="httpbin",


### PR DESCRIPTION
Fix for _UnicodeDecodeError_ of Python 3 when _setup.py_ is exectuted in non-UTF-8 environments with Python 2 backward compability.
