### PR TITLE
remove unused variable `form` from `helpers.get_dict`

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -169,7 +169,6 @@ def get_dict(*keys, **extras):
 
     assert all(map(_keys.__contains__, keys))
     data = request.data
-    form = request.form
     form = semiflatten(request.form)
 
     try:


### PR DESCRIPTION
remove unused variable `form` from `helpers.get_dict`