### PR TITLE
GH-307 Fix error 500 on digest auth with qop='auth-int'

### DIFF
--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -292,9 +292,10 @@ def HA2(credentails, request, algorithm):
         for k in 'method', 'uri', 'body':
             if k not in request:
                 raise ValueError("%s required" % k)
-        return H("%s:%s:%s" % (request['method'],
-                               request['uri'],
-                               H(request['body'], algorithm)), algorithm)
+        A2 = b":".join([request['method'].encode('utf-8'),
+                        request['uri'].encode('utf-8'),
+                        H(request['body'], algorithm).encode('utf-8')])
+        return H(A2, algorithm)
     raise ValueError
 
 

--- a/httpbin/helpers.py
+++ b/httpbin/helpers.py
@@ -294,7 +294,7 @@ def HA2(credentails, request, algorithm):
                 raise ValueError("%s required" % k)
         return H("%s:%s:%s" % (request['method'],
                                request['uri'],
-                               H(request['body'])), algorithm)
+                               H(request['body'], algorithm)), algorithm)
     raise ValueError
 
 

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -244,7 +244,8 @@ class HttpbinTestCase(unittest.TestCase):
                 'Authorization': auth_header,
             }
         )
-        assert 'Digest' in response.headers.get('WWW-Authenticate')
+        self.assertTrue('Digest' in response.headers.get('WWW-Authenticate'))
+        self.assertEqual(response.status_code, 401)
 
     def test_digest_auth(self):
         # make first request

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -37,7 +37,7 @@ def _string_to_base64(string):
     return base64.urlsafe_b64encode(utf8_encoded)
 
 def _hash(data, algorithm):
-    """Encode binary data according to specified algorithm"""
+    """Encode binary data according to specified algorithm, use MD5 by default"""
     if algorithm == 'SHA-256':
         return sha256(data).hexdigest()
     else:
@@ -46,17 +46,17 @@ def _hash(data, algorithm):
 def _make_digest_auth_header(username, password, method, uri, nonce,
                              realm=None, opaque=None, algorithm=None,
                              qop=None, cnonce=None, nc=None, body=None):
-    """Compile a digest authentication header string
+    """Compile a digest authentication header string.
 
     Arguments:
-    - `nonce': nonce string, received within "WWW-Authenticate" header
+    - `nonce`: nonce string, received within "WWW-Authenticate" header
     - `realm`: realm string, received within "WWW-Authenticate" header
     - `opaque`: opaque string, received within "WWW-Authenticate" header
     - `algorithm`: type of hashing algorithm, used by the client
     - `qop`: type of quality-of-protection, used by the client
     - `cnonce`: client nonce, required if qop is "auth" or "auth-int"
     - `nc`: client nonce count, required if qop is "auth" or "auth-int"
-    - `body`: body of the outgoing request
+    - `body`: body of the outgoing request, used if qop is "auth-int"
     """
 
     assert username
@@ -89,6 +89,7 @@ def _make_digest_auth_header(username, password, method, uri, nonce,
         'Digest username="{0}", response="{1}", uri="{2}", nonce="{3}"'\
             .format(username, auth_response, uri, nonce)
 
+    # 'realm' and 'opaque' should be returned unchanged, even if empty
     if realm != None:
         auth_header += ', realm="{0}"'.format(realm)
     if opaque != None:


### PR DESCRIPTION
Fix typo in HA2() function, which caused Digest auth test to fail, when 'qop' parameter is set to 'auth-int'.
