### PR TITLE
Add endpoint /echo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ Endpoint                                 Description
 `/forms/post`_                           HTML form that submits to */post*
 `/xml`_                                  Returns some XML
 `/encoding/utf8`_                        Returns page containing UTF-8 data.
+`/echo`_                                 Echoes request body.
 ======================================   ==================================================================================================================
 
 .. _/user-agent: http://httpbin.org/user-agent
@@ -94,6 +95,7 @@ Endpoint                                 Description
 .. _/forms/post: http://httpbin.org/forms/post
 .. _/xml: http://httpbin.org/xml
 .. _/encoding/utf8: http://httpbin.org/encoding/utf8
+.. _/echo: http://httpbin/echo
 
 
 DESCRIPTION
@@ -182,6 +184,13 @@ $ curl https://httpbin.org/get?show\_env=1
       "origin": "109.60.101.240",
       "url": "http://httpbin.org/get?show_env=1"
     }
+
+$ curl https://httpbin.org/echo -d "request body"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    request body
 
 Installing and running from PyPI
 --------------------------------

--- a/httpbin/core.py
+++ b/httpbin/core.py
@@ -720,6 +720,11 @@ def xml():
     return response
 
 
+@app.route('/echo', methods=('POST', 'GET'))
+def handle_echo():
+    return request.get_data()
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=int, default=5000)

--- a/test_httpbin.py
+++ b/test_httpbin.py
@@ -462,6 +462,15 @@ class HttpbinTestCase(unittest.TestCase):
         self.assertIn('google-analytics', data)
         self.assertIn('perfectaudience', data)
 
+    def test_echo_returns_request_body_in_response(self):
+        response = self.app.post('/echo', data='post body')
+
+        self.assertEqual(response.get_data(), b'post body')
+
+    def test_echo_supports_get_and_post_methods(self):
+        responses = [self.app.post('/echo'), self.app.get('/echo')]
+
+        self.assertEqual([resp.status_code for resp in responses], [200, 200])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`/echo` returns request body.
E.g.
```
$ curl -v http://localhost:5000/echo -d "body"

> POST /echo HTTP/1.1
> User-Agent: curl/7.38.0
> Host: localhost:5000
> Accept: */*
> Content-Length: 4
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.0 200 OK
< Content-Type: text/html; charset=utf-8
< Content-Length: 4
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< Server: Werkzeug/0.9.4 Python/3.5.2
< Date: Tue, 29 Nov 2016 20:11:31 GMT
< 
body 
```

Such endpoint becomes useful when we are testing proxy servers - how they are handling request body, etc.